### PR TITLE
prefer server setting for api_url over url param

### DIFF
--- a/client/js/_player/reducers/settings.js
+++ b/client/js/_player/reducers/settings.js
@@ -3,15 +3,28 @@ import _ from 'lodash';
 // These player settings should be numbers. Change them once here and be done with it.
 export const integerSettings = [ "user_id", "max_attempts", "questions_per_section", "questions_per_page", "audio_recorder_timeout"];
 
+// Allow these server-side settings to take priority over the URL params,
+// so content can be more portable.
+const serverSettingsTakePriority = ['api_url'];
+
 export default (state = {}, action) => {
   return state; // Just return state. Don't let settings from the server mutate.
 };
 
-export function getInitialSettings(){
-  var settings = _.merge({}, ...arguments); // Add default settings that can be overriden by values in serverSettings
+export function getInitialSettings(...args) {
+  var settings = _.merge({}, ...args);
+  // Add default settings that can be overriden by values in serverSettings
 
   _.each(integerSettings, (setting) => {
     if(settings[setting]){settings[setting] = parseInt(settings[setting]);}
+  });
+
+  // assumes that the serverSettings are always the first argument,
+  //   which is expected given currently URL params overwrite
+  //   serverSettings (due to how _.merge works)
+  _.each(serverSettingsTakePriority, (setting) => {
+    if (settings[setting] && args[0][setting] && args[0][setting] !== '')
+    { settings[setting] = args[0][setting]; }
   });
 
   return settings;

--- a/client/js/_player/reducers/settings.spec.js
+++ b/client/js/_player/reducers/settings.spec.js
@@ -29,5 +29,33 @@ describe('settings reducer', () => {
       const settings = getInitialSettings(serverSettings);
       expect(settings.questions_per_page).toEqual(1);
     });
+
+    it("Maintains the server setting for api_url", () => {
+      const serverSettings1 = { api_url: "localhost" };
+      const serverSettings2 = { api_url: "www.example.com" };
+      const settings = getInitialSettings(serverSettings1, serverSettings2);
+      expect(settings.api_url).toEqual("localhost");
+    });
+
+    it("Users query params for api_url if server settings is empty string", () => {
+      const serverSettings1 = { api_url: "" };
+      const serverSettings2 = { api_url: "www.example.com" };
+      const settings = getInitialSettings(serverSettings1, serverSettings2);
+      expect(settings.api_url).toEqual("www.example.com");
+    });
+
+    it("Users query params for api_url if server settings is null", () => {
+      const serverSettings1 = { api_url: null };
+      const serverSettings2 = { api_url: "www.example.com" };
+      const settings = getInitialSettings(serverSettings1, serverSettings2);
+      expect(settings.api_url).toEqual("www.example.com");
+    });
+
+    it("Users query params for api_url if server settings is not present", () => {
+      const serverSettings1 = { foo: "bar" };
+      const serverSettings2 = { api_url: "www.example.com" };
+      const settings = getInitialSettings(serverSettings1, serverSettings2);
+      expect(settings.api_url).toEqual("www.example.com");
+    });
   });
 });

--- a/client/js/_player/reducers/settings.spec.js
+++ b/client/js/_player/reducers/settings.spec.js
@@ -37,21 +37,21 @@ describe('settings reducer', () => {
       expect(settings.api_url).toEqual("localhost");
     });
 
-    it("Users query params for api_url if server settings is empty string", () => {
+    it("Uses query params for api_url if server settings is empty string", () => {
       const serverSettings1 = { api_url: "" };
       const serverSettings2 = { api_url: "www.example.com" };
       const settings = getInitialSettings(serverSettings1, serverSettings2);
       expect(settings.api_url).toEqual("www.example.com");
     });
 
-    it("Users query params for api_url if server settings is null", () => {
+    it("Uses query params for api_url if server settings is null", () => {
       const serverSettings1 = { api_url: null };
       const serverSettings2 = { api_url: "www.example.com" };
       const settings = getInitialSettings(serverSettings1, serverSettings2);
       expect(settings.api_url).toEqual("www.example.com");
     });
 
-    it("Users query params for api_url if server settings is not present", () => {
+    it("Uses query params for api_url if server settings is not present", () => {
       const serverSettings1 = { foo: "bar" };
       const serverSettings2 = { api_url: "www.example.com" };
       const settings = getInitialSettings(serverSettings1, serverSettings2);


### PR DESCRIPTION
This prefers the OEA player config setting for `api_url` over a URL provided in an `iframe` `src`.