### PR TITLE
Feature/cs/n of m flag when authoring

### DIFF
--- a/client/js/_author/components/assessments/_edit_assessment.jsx
+++ b/client/js/_author/components/assessments/_edit_assessment.jsx
@@ -46,6 +46,8 @@ export class EditAssessment extends React.Component {
     getAssessments: React.PropTypes.func.isRequired,
     updateAssessment: React.PropTypes.func.isRequired,
     updateSingleItemOrPage: React.PropTypes.func.isRequired,
+    updateNofM: React.PropTypes.func.isRequired,
+    createAssessmentOffered: React.PropTypes.func.isRequired,
     updateAssessmentItems: React.PropTypes.func.isRequired,
     getAssessmentItems: React.PropTypes.func.isRequired,
     createItemInAssessment: React.PropTypes.func.isRequired,
@@ -102,6 +104,11 @@ export class EditAssessment extends React.Component {
     );
   }
 
+  updateNofM(nOfM) {
+    const { assessment } = this.props;
+    this.props.updateNofM(assessment, nOfM);
+  }
+
   updateSingleItemOrPage(setSinglePage) {
     const { settings, assessment } = this.props;
     const { assessmentOffered } = assessment;
@@ -147,6 +154,7 @@ export class EditAssessment extends React.Component {
           bankId={this.props.params.bankId}
           publishedAndOffered={publishedAndOffered}
           updateSingleItemOrPage={setSinglePage => this.updateSingleItemOrPage(setSinglePage)}
+          updateNofM={nOfM => this.updateNofM(nOfM)}
           {...this.props.assessment}
           updateAssessment={newFields => this.updateAssessment(newFields)}
           updateItemOrder={itemIds => this.updateItemOrder(itemIds)}

--- a/client/js/_author/components/assessments/_edit_assessment.jsx
+++ b/client/js/_author/components/assessments/_edit_assessment.jsx
@@ -34,7 +34,7 @@ export class EditAssessment extends React.Component {
     assessment: React.PropTypes.shape({
       id: React.PropTypes.string,
       bankId: React.PropTypes.string,
-      assessmentOffered: React.PropTypes.shape({}),
+      assessmentOffered: React.PropTypes.arrayOf(React.PropTypes.shape({})),
       items: React.PropTypes.arrayOf(React.PropTypes.shape({})),
     }),
     settings: React.PropTypes.shape({
@@ -47,9 +47,9 @@ export class EditAssessment extends React.Component {
     updateAssessment: React.PropTypes.func.isRequired,
     updateSingleItemOrPage: React.PropTypes.func.isRequired,
     updateNofM: React.PropTypes.func.isRequired,
-    createAssessmentOffered: React.PropTypes.func.isRequired,
     updateAssessmentItems: React.PropTypes.func.isRequired,
     getAssessmentItems: React.PropTypes.func.isRequired,
+    getAssessmentOffered: React.PropTypes.func.isRequired,
     createItemInAssessment: React.PropTypes.func.isRequired,
     updateItem: React.PropTypes.func.isRequired,
     localizeStrings: React.PropTypes.func.isRequired,
@@ -62,6 +62,12 @@ export class EditAssessment extends React.Component {
   componentDidMount() {
     this.props.getAssessments(this.props.params.bankId);
     this.props.getAssessmentItems(
+      this.props.params.bankId,
+      this.props.params.id
+    );
+    // getAssessmentOffered so that N of M shows up properly
+    // and the Publish button won't create a new offered if one exists.
+    this.props.getAssessmentOffered(
       this.props.params.bankId,
       this.props.params.id
     );
@@ -106,7 +112,12 @@ export class EditAssessment extends React.Component {
 
   updateNofM(nOfM) {
     const { assessment } = this.props;
-    this.props.updateNofM(assessment, nOfM);
+    let finalNofM = nOfM;
+    if (!finalNofM) {
+      // if they selected the header option "N of M"
+      finalNofM = -1;
+    }
+    this.props.updateNofM(assessment, finalNofM);
   }
 
   updateSingleItemOrPage(setSinglePage) {

--- a/client/js/_author/components/assessments/_edit_assessment.jsx
+++ b/client/js/_author/components/assessments/_edit_assessment.jsx
@@ -34,7 +34,6 @@ export class EditAssessment extends React.Component {
     assessment: React.PropTypes.shape({
       id: React.PropTypes.string,
       bankId: React.PropTypes.string,
-      assessmentOffered: React.PropTypes.arrayOf(React.PropTypes.shape({})),
       items: React.PropTypes.arrayOf(React.PropTypes.shape({})),
     }),
     settings: React.PropTypes.shape({

--- a/client/js/_author/components/assessments/_edit_assessment.spec.jsx
+++ b/client/js/_author/components/assessments/_edit_assessment.spec.jsx
@@ -63,6 +63,7 @@ describe('_edit_assessment component', () => {
       updatePath: () => {},
       banks: [],
       updateSingleItemOrPage: () => {},
+      updateNofM: () => { handleFunction = true; },
       isPublished: false,
     };
     result = TestUtils.renderIntoDocument(<EditAssessment {...props} />);
@@ -105,6 +106,12 @@ describe('_edit_assessment component', () => {
   it('componentDidMount to be called', () => {
     expect(didMount).toBeTruthy();
     expect(didGetAssessmentItems).toBeTruthy();
+  });
+
+  it('runs updateNofM', () => {
+    expect(handleFunction).toBeFalsy();
+    result.updateNofM();
+    expect(handleFunction).toBeTruthy();
   });
 
 });

--- a/client/js/_author/components/assessments/_edit_assessment.spec.jsx
+++ b/client/js/_author/components/assessments/_edit_assessment.spec.jsx
@@ -10,11 +10,13 @@ describe('_edit_assessment component', () => {
   let handleFunction;
   let didMount;
   let didGetAssessmentItems;
+  let didGetAssessmentOffered;
 
   beforeEach(() => {
     handleFunction = false;
     didMount = false;
     didGetAssessmentItems = false;
+    didGetAssessmentOffered = false;
 
     props = {
       params: {
@@ -45,6 +47,7 @@ describe('_edit_assessment component', () => {
       updateAssessmentItems: () => { handleFunction = true; },
       getAssessmentItems: () => { didGetAssessmentItems = true; },
       createItemInAssessment: () => { handleFunction = true; },
+      getAssessmentOffered: () => { didGetAssessmentOffered = true; },
       updateItem: () => { handleFunction = true; },
       items: [
         {
@@ -64,6 +67,7 @@ describe('_edit_assessment component', () => {
       banks: [],
       updateSingleItemOrPage: () => {},
       updateNofM: () => { handleFunction = true; },
+      createAssessmentOffered: () => {},
       isPublished: false,
     };
     result = TestUtils.renderIntoDocument(<EditAssessment {...props} />);
@@ -106,6 +110,7 @@ describe('_edit_assessment component', () => {
   it('componentDidMount to be called', () => {
     expect(didMount).toBeTruthy();
     expect(didGetAssessmentItems).toBeTruthy();
+    expect(didGetAssessmentOffered).toBeTruthy();
   });
 
   it('runs updateNofM', () => {

--- a/client/js/_author/components/assessments/_edit_assessment.spec.jsx
+++ b/client/js/_author/components/assessments/_edit_assessment.spec.jsx
@@ -108,15 +108,15 @@ describe('_edit_assessment component', () => {
   });
 
   it('componentDidMount to be called', () => {
-    expect(didMount).toBeTruthy();
-    expect(didGetAssessmentItems).toBeTruthy();
-    expect(didGetAssessmentOffered).toBeTruthy();
+    expect(didMount).toEqual(true);
+    expect(didGetAssessmentItems).toEqual(true);
+    expect(didGetAssessmentOffered).toEqual(true);
   });
 
   it('runs updateNofM', () => {
-    expect(handleFunction).toBeFalsy();
+    expect(handleFunction).toEqual(false);
     result.updateNofM();
-    expect(handleFunction).toBeTruthy();
+    expect(handleFunction).toEqual(true);
   });
 
 });

--- a/client/js/_author/components/assessments/assessment_form.jsx
+++ b/client/js/_author/components/assessments/assessment_form.jsx
@@ -79,11 +79,15 @@ class AssessmentForm extends React.Component {
     const strings = this.props.localizeStrings('assessmentForm');
     return (
       <div className="au-o-item__top">
-        <div className="au-c-dropdown au-c-dropdown--small au-u-ml-md au-u-right">
+        <div className="au-c-dropdown au-c-dropdown--small au-c-dropdown-with-side-label au-c-input-label--left au-u-ml-md au-u-right">
+          <label
+            className="au-u-mr-sm"
+            htmlFor="nOfM"
+          >
+            {strings.nOfMLabel}</label>
           <select
-            aria-label={strings.nOfMLabel}
             onChange={e => this.props.updateNofM(e.target.value)}
-            name=""
+            name="nOfM"
             id="nOfM"
             value={this.props.assessmentOffered &&
               this.props.assessmentOffered.length > 0 ?

--- a/client/js/_author/components/assessments/assessment_form.jsx
+++ b/client/js/_author/components/assessments/assessment_form.jsx
@@ -81,7 +81,7 @@ class AssessmentForm extends React.Component {
       <div className="au-o-item__top">
         <div className="au-c-dropdown au-c-dropdown--small au-u-ml-md au-u-right">
           <select
-            ariaLabel={strings.nOfMLabel}
+            aria-label={strings.nOfMLabel}
             onChange={e => this.props.updateNofM(e.target.value)}
             name=""
             id="nOfM"

--- a/client/js/_author/components/assessments/assessment_form.jsx
+++ b/client/js/_author/components/assessments/assessment_form.jsx
@@ -23,6 +23,7 @@ class AssessmentForm extends React.Component {
     updateNofM: React.PropTypes.func,
     deleteAssessmentItem: React.PropTypes.func,
     localizeStrings: React.PropTypes.func,
+    assessmentOffered: React.PropTypes.shape
   };
 
   constructor() {
@@ -80,7 +81,8 @@ class AssessmentForm extends React.Component {
         <div className="au-c-dropdown au-c-dropdown--small au-u-ml-md au-u-right">
           <label htmlFor="assessmentFormSelect01" />
           <select
-            defaultValue={-1}
+            defaultValue={this.props.assessmentOffered ?
+              this.props.assessmentOffered.nOfM : -1}
             onChange={e => this.props.updateNofM(e.target.value)}
             name=""
             id="nOfM"

--- a/client/js/_author/components/assessments/assessment_form.jsx
+++ b/client/js/_author/components/assessments/assessment_form.jsx
@@ -23,7 +23,8 @@ class AssessmentForm extends React.Component {
     updateNofM: React.PropTypes.func,
     deleteAssessmentItem: React.PropTypes.func,
     localizeStrings: React.PropTypes.func,
-    assessmentOffered: React.PropTypes.shape
+    assessmentOffered: React.PropTypes.arrayOf(
+      React.PropTypes.shape({ nOfM: React.PropTypes.number }))
   };
 
   constructor() {
@@ -79,20 +80,21 @@ class AssessmentForm extends React.Component {
     return (
       <div className="au-o-item__top">
         <div className="au-c-dropdown au-c-dropdown--small au-u-ml-md au-u-right">
-          <label htmlFor="assessmentFormSelect01" />
           <select
-            defaultValue={this.props.assessmentOffered ?
-              this.props.assessmentOffered.nOfM : -1}
+            ariaLabel={strings.nOfMLabel}
             onChange={e => this.props.updateNofM(e.target.value)}
             name=""
             id="nOfM"
+            value={this.props.assessmentOffered &&
+              this.props.assessmentOffered.length > 0 ?
+              this.props.assessmentOffered[0].nOfM : -1}
           >
             <option
               className="n-of-m-option"
-              key="n_of_m_off"
+              key="n_of_m_all"
               value={-1}
             >
-              {strings.nOfMLabel}</option>
+              {strings.all}</option>
             {
               _.map(_.range(1, this.props.items.length), (ind) => {
                 const label = stringFormatter.formatString(

--- a/client/js/_author/components/assessments/assessment_form.jsx
+++ b/client/js/_author/components/assessments/assessment_form.jsx
@@ -5,6 +5,9 @@ import AddQuestion     from './add_question_button';
 import Question        from './question_types/_question';
 import localize        from '../../locales/localize';
 
+// ideally we would get this directly from this.props.localizeStrings...
+import stringFormatter from '../../locales/locales';
+
 class AssessmentForm extends React.Component {
   static propTypes = {
     items: React.PropTypes.oneOfType(
@@ -17,6 +20,7 @@ class AssessmentForm extends React.Component {
     publishedAndOffered: React.PropTypes.bool,
     createItem: React.PropTypes.func,
     updateSingleItemOrPage: React.PropTypes.func,
+    updateNofM: React.PropTypes.func,
     deleteAssessmentItem: React.PropTypes.func,
     localizeStrings: React.PropTypes.func,
   };
@@ -59,7 +63,62 @@ class AssessmentForm extends React.Component {
     this.props.updateItemOrder(itemIds);
   }
 
+  showNofMOption() {
+    // Always show this option when editing an assessment
+    // N is the number of questions the student has to answer
+    // M is the total number of questions in the assessment
+    // N < M. If N == M, then we just send -1 to the server, to indicate
+    //    that the student has to answer all questions, so we leave
+    //    the N == M option out of the selector.
+    if (!this.props.items) {
+      return null;
+    }
+
+    const strings = this.props.localizeStrings('assessmentForm');
+    return (
+      <div className="au-o-item__top">
+        <div className="au-c-dropdown au-c-dropdown--small au-u-ml-md au-u-right">
+          <label htmlFor="assessmentFormSelect01" />
+          <select
+            defaultValue={-1}
+            onChange={e => this.props.updateNofM(e.target.value)}
+            name=""
+            id="nOfM"
+          >
+            <option
+              className="n-of-m-option"
+              key="n_of_m_off"
+              value={-1}
+            >
+              {strings.nOfMLabel}</option>
+            {
+              _.map(_.range(1, this.props.items.length), (ind) => {
+                const label = stringFormatter.formatString(
+                  strings.nOfM,
+                  ind,
+                  this.props.items.length
+                );
+                return (
+                  <option
+                    className="n-of-m-option"
+                    key={`n_of_m_${ind}`}
+                    value={ind}
+                  >
+                    {label}
+                  </option>
+                );
+              })
+            }
+          </select>
+        </div>
+      </div>
+    );
+  }
+
   showSinglePageOption() {
+    // Now that publishing disallows you from editing the assessment,
+    //   if you want to show this section, you need to remove the
+    //   if() conditional.
     if (this.props.publishedAndOffered) {
       const strings = this.props.localizeStrings('assessmentForm');
       return (
@@ -96,6 +155,7 @@ class AssessmentForm extends React.Component {
     return (
       <div className="au-o-contain">
         <div className="au-o-item">
+          {this.showNofMOption()}
           {this.showSinglePageOption()}
           <div className="au-c-assessment-title">
             <label htmlFor="title_field" className="au-c-input test_label">

--- a/client/js/_author/components/assessments/assessment_form.jsx
+++ b/client/js/_author/components/assessments/assessment_form.jsx
@@ -79,7 +79,7 @@ class AssessmentForm extends React.Component {
     const strings = this.props.localizeStrings('assessmentForm');
     return (
       <div className="au-o-item__top">
-        <div className="au-c-dropdown au-c-dropdown--small au-c-dropdown-with-side-label au-c-input-label--left au-u-ml-md au-u-right">
+        <div className="au-c-dropdown au-c-dropdown--small au-c-dropdown--side-label au-c-input-label--left au-u-ml-md au-u-right">
           <label
             className="au-u-mr-sm"
             htmlFor="nOfM"

--- a/client/js/_author/components/assessments/assessment_form.spec.jsx
+++ b/client/js/_author/components/assessments/assessment_form.spec.jsx
@@ -25,6 +25,17 @@ describe('AssessmentForm component', () => {
           },
           choices: [],
         },
+      }, {
+        id: '78',
+        name: 'IMATITLESPEC',
+        type: '3',
+        index: 2,
+        question: {
+          text: {
+            name: 'NAMEME',
+          },
+          choices: [],
+        },
       }],
       bankId: '',
       name: 'IMASPEC',
@@ -46,6 +57,24 @@ describe('AssessmentForm component', () => {
 
   it('renders one labels', () => {
     expect(result.find('.test_label').length).toBe(1);
+  });
+
+  it('renders the N of M selector', () => {
+    expect(result.find('#nOfM').length).toBe(1);
+  });
+
+  it('shows equal number of select options as number of items', () => {
+    // Note that the first select is always "N of M" -- thus
+    //   for assessment with 1 item, no additional options
+    expect(result.find('.n-of-m-option').length).toBe(2);
+  });
+
+  it('shows a counter for N of M options', () => {
+    expect(result.find('.n-of-m-option').length).toBe(2);
+  });
+
+  it('formats the N of M option text correct', () => {
+    expect(result.find('.n-of-m-option').last().html()).toContain('1 of 2');
   });
 
   it('creates a new item', () => {

--- a/client/js/_author/components/assessments/assessment_form.spec.jsx
+++ b/client/js/_author/components/assessments/assessment_form.spec.jsx
@@ -37,8 +37,11 @@ describe('AssessmentForm component', () => {
           choices: [],
         },
       }],
-      bankId: '',
+      bankId: '123',
       name: 'IMASPEC',
+      assessmentOffered: [{
+        nOfM: 1
+      }],
       updateAssessment: () => {},
       updateItemOrder: () => { updateItemOrderFunction = true; },
       createItem: () => { createItem = true; },
@@ -64,17 +67,29 @@ describe('AssessmentForm component', () => {
   });
 
   it('shows equal number of select options as number of items', () => {
-    // Note that the first select is always "N of M" -- thus
+    // Note that the first select is always "all"
     //   for assessment with 1 item, no additional options
-    expect(result.find('.n-of-m-option').length).toBe(2);
-  });
-
-  it('shows a counter for N of M options', () => {
     expect(result.find('.n-of-m-option').length).toBe(2);
   });
 
   it('formats the N of M option text correct', () => {
     expect(result.find('.n-of-m-option').last().html()).toContain('1 of 2');
+  });
+
+  it('should pull N of M from the offered', () => {
+    expect(result.find('select').prop('value')).toEqual(1);
+  });
+
+  it('should have default N of M value when no offereds', () => {
+    props.assessmentOffered = [];
+    result = shallow(<AssessmentForm {...props} />);
+    expect(result.find('select').prop('value')).toEqual(-1);
+  });
+
+  it('should have default N of M value when offereds not defined', () => {
+    props.assessmentOffered = null;
+    result = shallow(<AssessmentForm {...props} />);
+    expect(result.find('select').prop('value')).toEqual(-1);
   });
 
   it('creates a new item', () => {
@@ -112,4 +127,5 @@ describe('AssessmentForm component', () => {
     result.instance().moveItem(oldIndex, newIndex);
     expect(updateItemOrderFunction).toBeTruthy();
   });
+
 });

--- a/client/js/_author/components/assessments/assessment_form.spec.jsx
+++ b/client/js/_author/components/assessments/assessment_form.spec.jsx
@@ -66,6 +66,15 @@ describe('AssessmentForm component', () => {
     expect(result.find('#nOfM').length).toBe(1);
   });
 
+  it('includes the right class so renders in one line', () => {
+    expect(result.find('.au-c-dropdown--side-label').length).toBe(1);
+  });
+
+  it('renders the label', () => {
+    expect(result.find('label.au-u-mr-sm').length).toBe(1);
+    expect(result.find('label.au-u-mr-sm').html()).toContain('for="nOfM"');
+  });
+
   it('shows equal number of select options as number of items', () => {
     // Note that the first select is always "all"
     //   for assessment with 1 item, no additional options

--- a/client/js/_author/locales/en.js
+++ b/client/js/_author/locales/en.js
@@ -36,7 +36,8 @@ export default {
       singlePageAssessment: 'Single page assessment',
       nameRequired: 'Name is required in order to edit',
       placeholder: 'Untitled Assessment',
-      nOfMLabel: 'N of M',
+      nOfMLabel: 'N of M selector',
+      all: 'All questions',
       nOfM: '{0} of {1}'
     },
     audioLimit: {

--- a/client/js/_author/locales/en.js
+++ b/client/js/_author/locales/en.js
@@ -35,7 +35,9 @@ export default {
     assessmentForm: {
       singlePageAssessment: 'Single page assessment',
       nameRequired: 'Name is required in order to edit',
-      placeholder: 'Untitled Assessment'
+      placeholder: 'Untitled Assessment',
+      nOfMLabel: 'N of M',
+      nOfM: '{0} of {1}'
     },
     audioLimit: {
       rangeWarning: 'Please enter a positive number under'

--- a/client/js/_author/reducers/assessments.js
+++ b/client/js/_author/reducers/assessments.js
@@ -21,11 +21,24 @@ export default function banks(state = initialState, action) {
 
     case 'UPDATE_ASSESSMENT_DONE': {
       const newState = _.cloneDeep(state);
+
       const bankId = action.payload.bankId;
       if (!newState[bankId]) {
         newState[bankId] = {};
       }
+
+      // to preserve the assessmentOffered in state tree,
+      // when tabbing back to N of M or editing the assessment
+      let existingAssessmentOffereds = [];
+
+      if (bankId in state &&
+          action.payload.id in state[bankId] &&
+          'assessmentOffered' in state[bankId][action.payload.id]) {
+        existingAssessmentOffereds = state[bankId][action.payload.id].assessmentOffered;
+      }
+
       newState[bankId][action.payload.id] = action.payload;
+      newState[bankId][action.payload.id].assessmentOffered = existingAssessmentOffereds;
       return newState;
     }
 
@@ -85,12 +98,15 @@ export default function banks(state = initialState, action) {
       //   ....but just in case not.
       if (action.original.bankId in newState &&
           action.original.assessmentId in newState[action.original.bankId] &&
-          newState[action.original.bankId][action.original.assessmentId].assessmentOffered) {
+          newState[action.original.bankId][action.original.assessmentId].assessmentOffered &&
+          newState[action.original.bankId][
+            action.original.assessmentId
+          ].assessmentOffered.length > 0) {
         newState[
           action.original.bankId
         ][
           action.original.assessmentId
-        ].assessmentOffered.nOfM = action.payload;
+        ].assessmentOffered[0].nOfM = action.payload;
       }
       return newState;
     }

--- a/client/js/_author/reducers/assessments.js
+++ b/client/js/_author/reducers/assessments.js
@@ -78,6 +78,23 @@ export default function banks(state = initialState, action) {
       return newState;
     }
 
+    case 'UPDATE_N_OF_M_DONE': {
+      const newState = _.cloneDeep(state);
+
+      // An offered should always exist by this point
+      //   ....but just in case not.
+      if (action.original.bankId in newState &&
+          action.original.assessmentId in newState[action.original.bankId] &&
+          newState[action.original.bankId][action.original.assessmentId].assessmentOffered) {
+        newState[
+          action.original.bankId
+        ][
+          action.original.assessmentId
+        ].assessmentOffered.nOfM = action.payload;
+      }
+      return newState;
+    }
+
     case 'DELETE_ASSESSMENT_DONE': {
       const newState = _.cloneDeep(state);
       const bankId = action.original.bankId;

--- a/client/js/_author/reducers/assessments.spec.js
+++ b/client/js/_author/reducers/assessments.spec.js
@@ -1,0 +1,57 @@
+import banks from './assessments';
+
+describe('assessments reducer', () => {
+  describe('initial state', () => {
+    it('returns empty state', () => {
+      const initialState = {};
+      const state = banks(initialState, {});
+      expect(state).toEqual({});
+    });
+  });
+
+  describe('update n of m done', () => {
+    it('updates the assessment offered value', () => {
+      const initialState = {
+        1: {
+          2: {
+            assessmentOffered: {
+              nOfM: -1
+            }
+          }
+        }
+      };
+      const action = {
+        original: {
+          bankId: 1,
+          assessmentId: 2
+        },
+        type: 'UPDATE_N_OF_M_DONE',
+        payload: 5
+      };
+      const state = banks(initialState, action);
+      expect(state[1][2].assessmentOffered.nOfM).toEqual(5);
+    });
+
+    it('does not update the assessment offered value of other assessments', () => {
+      const initialState = {
+        1: {
+          2: {
+            assessmentOffered: {
+              nOfM: -1
+            }
+          }
+        }
+      };
+      const action = {
+        original: {
+          bankId: 1,
+          assessmentId: 3
+        },
+        type: 'UPDATE_N_OF_M_DONE',
+        payload: 5
+      };
+      const state = banks(initialState, action);
+      expect(state[1][2].assessmentOffered.nOfM).toEqual(-1);
+    });
+  });
+});

--- a/client/js/_author/reducers/assessments.spec.js
+++ b/client/js/_author/reducers/assessments.spec.js
@@ -14,9 +14,9 @@ describe('assessments reducer', () => {
       const initialState = {
         1: {
           2: {
-            assessmentOffered: {
+            assessmentOffered: [{
               nOfM: -1
-            }
+            }]
           }
         }
       };
@@ -29,16 +29,16 @@ describe('assessments reducer', () => {
         payload: 5
       };
       const state = banks(initialState, action);
-      expect(state[1][2].assessmentOffered.nOfM).toEqual(5);
+      expect(state[1][2].assessmentOffered[0].nOfM).toEqual(5);
     });
 
     it('does not update the assessment offered value of other assessments', () => {
       const initialState = {
         1: {
           2: {
-            assessmentOffered: {
+            assessmentOffered: [{
               nOfM: -1
-            }
+            }]
           }
         }
       };
@@ -51,7 +51,7 @@ describe('assessments reducer', () => {
         payload: 5
       };
       const state = banks(initialState, action);
-      expect(state[1][2].assessmentOffered.nOfM).toEqual(-1);
+      expect(state[1][2].assessmentOffered[0].nOfM).toEqual(-1);
     });
   });
 });

--- a/client/js/actions/qbank/assessments.js
+++ b/client/js/actions/qbank/assessments.js
@@ -180,7 +180,9 @@ export function updateSingleItemOrPage(assessmentOffered, genusTypeId) {
 }
 
 export function updateNofM(assessment, nOfM) {
-  const offeredId = assessment.assessmentOffered ? assessment.assessmentOffered.id : null;
+  const offeredId = assessment.assessmentOffered &&
+    assessment.assessmentOffered.length > 0 ?
+    assessment.assessmentOffered[0].id : null;
   return {
     bankId: assessment.bankId,
     assessmentId: assessment.id,

--- a/client/js/actions/qbank/assessments.js
+++ b/client/js/actions/qbank/assessments.js
@@ -21,6 +21,7 @@ const requests = [
   'DELETE_ASSIGNED_ASSESSMENT',
   'GET_ASSESSMENT_PREVIEW',
   'UPDATE_SINGLE_ITEM_OR_PAGE',
+  'UPDATE_N_OF_M',
   'TOGGLE_PUBLISH_ASSESSMENT'
 ];
 
@@ -175,5 +176,17 @@ export function updateSingleItemOrPage(assessmentOffered, genusTypeId) {
     apiCall      : true,
     type         : Constants.UPDATE_SINGLE_ITEM_OR_PAGE,
     body         : { genusTypeId }
+  };
+}
+
+export function updateNofM(assessment, nOfM) {
+  const offeredId = assessment.assessmentOffered ? assessment.assessmentOffered.id : null;
+  return {
+    bankId: assessment.bankId,
+    assessmentId: assessment.id,
+    assessmentOfferedId: offeredId,
+    apiCall: true,
+    type: Constants.UPDATE_N_OF_M,
+    body: { nOfM }
   };
 }

--- a/client/js/middleware/qbank.js
+++ b/client/js/middleware/qbank.js
@@ -568,7 +568,6 @@ const qbank = {
       createAssessmentOffered(store, action.bankId, action.assessmentId, action.body)
       .then((res) => {
         const offered = res.body;
-        console.log('about to dispatch to the create offered action');
         store.dispatch({
           type: AssessmentConstants.CREATE_ASSESSMENT_OFFERED + DONE,
           original: action,

--- a/client/styles/_author/partials/_inputs.scss
+++ b/client/styles/_author/partials/_inputs.scss
@@ -367,7 +367,7 @@
   }
 }
 
-.au-c-dropdown-with-side-label {
+.au-c-dropdown--side-label {
   width: 30rem;
 }
 

--- a/client/styles/_author/partials/_inputs.scss
+++ b/client/styles/_author/partials/_inputs.scss
@@ -367,6 +367,10 @@
   }
 }
 
+.au-c-dropdown-with-side-label {
+  width: 30rem;
+}
+
 .au-c-checkbox{
 
   label{


### PR DESCRIPTION
@resource11 I have tested this with Chrome / Safari keyboard controls, as well as VoiceOver. The `aria-label` is read by VoiceOver when tabbing through.