### PR TITLE
also make the unlock previous setting work in the authoring preview

### DIFF
--- a/client/js/_author/components/preview/preview_container.jsx
+++ b/client/js/_author/components/preview/preview_container.jsx
@@ -26,8 +26,27 @@ export default class PreviewContainer extends React.Component {
     const { assessmentPlayerUrl, apiUrl, assessment, unlockNext } = this.props;
 
     const bankId = assessment.bankId;
-    const assessmentOfferedId = _.get(assessment, 'assessmentOffered[0].id');
-    const previewSettings = [`unlock_next=${unlockNext}`].join('&');
+    const assessmentOffered = _.get(assessment, 'assessmentOffered[0]');
+    const assessmentOfferedId = assessmentOffered.id;
+    const settings = [`unlock_next=${unlockNext}`];
+
+    if (assessmentOffered.unlockPrevious) {
+      switch (assessmentOffered.unlockPrevious) {
+        case 'ALWAYS':
+          settings.push('unlock_prev=ALWAYS');
+          break;
+
+        case 'NEVER':
+          settings.push('unlock_prev=NEVER');
+          break;
+
+        default:
+          break;
+      }
+
+    }
+
+    const previewSettings = settings.join('&');
 
     return `${assessmentPlayerUrl}?${previewSettings}&api_url=${apiUrl}&bank=${bankId}&assessment_offered_id=${assessmentOfferedId}#/assessment`;
   }

--- a/client/js/_author/components/preview/preview_container.spec.jsx
+++ b/client/js/_author/components/preview/preview_container.spec.jsx
@@ -34,8 +34,16 @@ describe('preview container component', () => {
   });
 
   describe('buildEmbedUrl', () => {
-    it('build embed url', () => {
+    it('build embed url without unlockPrevious', () => {
       const expectedResult = 'http://example.com?unlock_next=ON_CORRECT&api_url=http://api.example.com&bank=bankId&assessment_offered_id=assessOfferedId#/assessment';
+      const url = result.buildEmbedUrl(props);
+
+      expect(url).toEqual(expectedResult);
+    });
+
+    it('build embed url with unlockPrevious', () => {
+      props.assessment.assessmentOffered[0].unlockPrevious = 'ALWAYS';
+      const expectedResult = 'http://example.com?unlock_next=ON_CORRECT&unlock_prev=ALWAYS&api_url=http://api.example.com&bank=bankId&assessment_offered_id=assessOfferedId#/assessment';
       const url = result.buildEmbedUrl(props);
 
       expect(url).toEqual(expectedResult);


### PR DESCRIPTION
Makes the `unlockPrevious` setting appear in the authoring preview, too.