### PR TITLE
move the assessment settings selectors to below the name, and to the …

### DIFF
--- a/client/js/_author/components/assessments/assessment_form.jsx
+++ b/client/js/_author/components/assessments/assessment_form.jsx
@@ -72,6 +72,7 @@ class AssessmentForm extends React.Component {
   showAssessmentOptions() {
     return (
       <div className="au-o-item__top">
+        <div className="au-c-input-label--left au-u-ml-md au-u-right" />
         {this.showPreviousBtnOption()}
         {this.showNofMOption()}
         {this.showSinglePageOption()}
@@ -145,7 +146,7 @@ class AssessmentForm extends React.Component {
 
     const strings = this.props.localizeStrings('assessmentForm');
     return (
-      <div className="au-c-dropdown au-c-dropdown--small au-c-dropdown--side-label au-c-input-label--left au-u-ml-md au-u-left">
+      <div className="au-c-dropdown au-c-dropdown--small au-c-dropdown--side-label au-c-input-label--left au-u-ml-md au-u-right">
         <label
           className="au-u-mr-sm unlock-previous-label"
           htmlFor="unlockPrev"
@@ -214,7 +215,6 @@ class AssessmentForm extends React.Component {
     return (
       <div className="au-o-contain">
         <div className="au-o-item">
-          {this.showAssessmentOptions()}
           <div className="au-c-assessment-title">
             <label htmlFor="title_field" className="au-c-input test_label">
               <div className="au-c-input__contain">
@@ -238,6 +238,7 @@ class AssessmentForm extends React.Component {
               </div>
             </label>
           </div>
+          {this.showAssessmentOptions()}
         </div>
         { this.props.name ?
           _.map(_.compact(this.props.items), (item, index) => (


### PR DESCRIPTION
…right; [close #88, #89]

@resource11 I also attempted to move the buttons to the right, but I'm pretty sure you'll gag at the way I hacked that (the existing classes I used to scrunch things). So please review the CSS and make suggestions on how I can do it a cleaner way. I'm wondering if we need a newer set of classes? However we do that better would address issue #90.

Currently this looks better visually, though.

<img width="1057" alt="captura de pantalla 2017-07-28 a la s 12 14 35 pm" src="https://user-images.githubusercontent.com/4930129/28726270-8f7dd6fe-738e-11e7-876a-e26ff5f1694b.png">
