### PR TITLE
add next button to new assessment form; [close #84]

### DIFF
--- a/client/js/_author/components/assessments/assessment_form.spec.jsx
+++ b/client/js/_author/components/assessments/assessment_form.spec.jsx
@@ -1,6 +1,6 @@
 import React          from 'react';
 import { shallow }    from 'enzyme';
-import AssessmentForm from './assessment_form';
+import AssessmentForm, { DEFAULT_NAME } from './assessment_form';
 
 jest.mock('../../../libs/assets');
 
@@ -9,6 +9,7 @@ describe('AssessmentForm component', () => {
   let result;
   let createItem;
   let updateItemOrderFunction;
+  let calledUpdateAssessments = false;
 
   beforeEach(() => {
     createItem = false;
@@ -43,7 +44,7 @@ describe('AssessmentForm component', () => {
         nOfM: 1,
         unlockPrevious: 'NEVER'
       }],
-      updateAssessment: () => {},
+      updateAssessment: (value) => { calledUpdateAssessments = value; },
       updateItemOrder: () => { updateItemOrderFunction = true; },
       createItem: () => { createItem = true; },
       updateItem: () => {},
@@ -170,6 +171,65 @@ describe('AssessmentForm component', () => {
     const newIndex = '77';
     result.instance().moveItem(oldIndex, newIndex);
     expect(updateItemOrderFunction).toBeTruthy();
+  });
+
+  it('renders the next button on new assessments', () => {
+    props.bankId = '';
+    result = shallow(<AssessmentForm {...props} />);
+    expect(result.find('.au-c-assessment-next').length).toEqual(1);
+  });
+
+  it('does not render the next button when editing assessments', () => {
+    expect(result.find('.au-c-assessment-next').length).toEqual(0);
+  });
+
+  it('does not call updateAssessment onBlur for new assessment', () => {
+    props.bankId = '';
+    result = shallow(<AssessmentForm {...props} />);
+    result.find('input').simulate('blur', {
+      target: {
+        value: 'foo'
+      }
+    });
+    expect(calledUpdateAssessments).toEqual(false);
+    expect(result.state('title')).toEqual(DEFAULT_NAME);
+  });
+
+  it('disables the button if no text, for new assessment', () => {
+    props.bankId = '';
+    result = shallow(<AssessmentForm {...props} />);
+    result.find('button').simulate('click');
+    expect(calledUpdateAssessments).toEqual(false);
+  });
+
+  it('calls updateAssessment onClick of Next button for new assessment', () => {
+    props.bankId = '';
+    result = shallow(<AssessmentForm {...props} />);
+    result.setState({ title: 'foo' });
+    result.find('button').simulate('click');
+    expect(calledUpdateAssessments).toEqual({
+      name: 'foo'
+    });
+  });
+
+  it('sets the savingAssessment state to true, onClick of Next button for new assessment', () => {
+    props.bankId = '';
+    result = shallow(<AssessmentForm {...props} />);
+    result.setState({ title: 'foo' });
+    expect(result.state('savingAssessment')).toEqual(false);
+    result.find('button').simulate('click');
+    expect(result.state('savingAssessment')).toEqual(true);
+  });
+
+  it('calls updateAssessment onBlur for existing assessment', () => {
+    result.find('input').simulate('blur', {
+      target: {
+        value: 'foo'
+      }
+    });
+    expect(calledUpdateAssessments).toEqual({
+      name: 'foo'
+    });
   });
 
 });

--- a/client/js/_author/locales/en.js
+++ b/client/js/_author/locales/en.js
@@ -41,7 +41,8 @@ export default {
       nOfM: '{0} of {1}',
       prevBtnLabel: 'Unlock Previous',
       prevBtnAlways: 'Always',
-      prevBtnNever: 'Never'
+      prevBtnNever: 'Never',
+      saveAssessmentTitle: 'Next'
     },
     audioLimit: {
       rangeWarning: 'Please enter a positive number under'

--- a/client/styles/_author/modules/_colors.scss
+++ b/client/styles/_author/modules/_colors.scss
@@ -5,6 +5,7 @@ $black: #000000;
 $purple: #4C4085;
 $purple2: #615696;
 $maroon: #912A7D;
+$maroon-disabled: rgba(145, 42, 125, 0.5);
 $blue: #4F7DB2;
 $blue2: #6393C9;
 $green: #2BAB6D;

--- a/client/styles/_author/partials/_buttons.scss
+++ b/client/styles/_author/partials/_buttons.scss
@@ -122,6 +122,16 @@
     background-color: $white;
     color: $maroon;
   }
+
+  &.is-inactive{
+    background-color: $maroon-disabled;
+    border-color: $maroon-disabled;
+    color: rgba(255,255,255,0.5);
+    pointer-events: none;
+    i{
+      color: rgba(255,255,255,0.5);
+    }
+  }
 }
 
   .au-c-btn--new{

--- a/client/styles/_author/partials/_questions.scss
+++ b/client/styles/_author/partials/_questions.scss
@@ -11,6 +11,11 @@
   }
 }
 
+.au-c-assessment-next{
+  display: block;
+  margin-top: 2rem;
+}
+
 .au-c-question-settings{
   display: none;
   height: 5rem;


### PR DESCRIPTION
This should do several things (tested manually):

- Adds a next button that is, by default, disabled (and not keyboard tabbable? At least on my system I couldn't get to it).
- When you type into the text input, the button is enabled. Removing your text re-disables the button.
- When the button is enabled, it is then tab-able.
- Tabbing out of the text input does **not** trigger the "save" action. But should take you to the button (the focus ring isn't very obvious here...that should get fixed somehow).
- Entering / activating the button **does** trigger the "save" action.
- The "edit assessment" form should behave the same as before -- no button, and updates the assessment name automatically on blur / tab-out of the field.

I hacked up some styling for the disabled button, using the `is-inactive` class that is already in the app. For some reason, when I only added the `disabled` attribute to the button, nothing visibly changed in the button (even though it was disabled and un-clickable)...not sure if that is because of overriding CSS somewhere. If you have recommendations for how to do it better, please let me know.
