### PR TITLE
set drop objects to always expanded; [close #124]

### DIFF
--- a/client/js/_author/components/assessments/question_types/drag_and_drop/__snapshots__/drag_area.spec.jsx.snap
+++ b/client/js/_author/components/assessments/question_types/drag_and_drop/__snapshots__/drag_area.spec.jsx.snap
@@ -12,7 +12,7 @@ ShallowWrapper {
     className="au-c-drop-zone__answers au-o-row"
 >
     <dropObject
-        isActive={false}
+        isActive={true}
         language="639-2%3AENG%40ISO"
         object={
             Object {
@@ -59,7 +59,7 @@ ShallowWrapper {
       className="au-c-drop-zone__answers au-o-row"
 >
       <dropObject
-            isActive={false}
+            isActive={true}
             language="639-2%3AENG%40ISO"
             object={
                   Object {
@@ -181,7 +181,7 @@ ShallowWrapper {
           className="au-c-drop-zone__answers au-o-row"
 >
           <dropObject
-                    isActive={false}
+                    isActive={true}
                     language="639-2%3AENG%40ISO"
                     object={
                               Object {
@@ -228,7 +228,7 @@ ShallowWrapper {
           className="au-c-drop-zone__answers au-o-row"
 >
           <dropObject
-                    isActive={false}
+                    isActive={true}
                     language="639-2%3AENG%40ISO"
                     object={
                               Object {

--- a/client/js/_author/components/assessments/question_types/drag_and_drop/drag_area.jsx
+++ b/client/js/_author/components/assessments/question_types/drag_and_drop/drag_area.jsx
@@ -42,7 +42,7 @@ class DragArea extends React.Component {
               object={object}
               zones={this.props.zones}
               setActive={() => this.setState({ activeObject: object.id })}
-              isActive={this.state.activeObject === object.id}
+              isActive={true}
               updateObject={newAttributes => this.props.updateDropObject(object.id, newAttributes)}
               uploadMedia={this.props.uploadMedia}
               language={this.props.language}

--- a/client/js/_author/components/assessments/question_types/drag_and_drop/drag_area.jsx
+++ b/client/js/_author/components/assessments/question_types/drag_and_drop/drag_area.jsx
@@ -42,7 +42,7 @@ class DragArea extends React.Component {
               object={object}
               zones={this.props.zones}
               setActive={() => this.setState({ activeObject: object.id })}
-              isActive={true}
+              isActive
               updateObject={newAttributes => this.props.updateDropObject(object.id, newAttributes)}
               uploadMedia={this.props.uploadMedia}
               language={this.props.language}


### PR DESCRIPTION
set `isActive` to always true, so the drop object components are all expanded in the authoring UI. Easier to check that you've selected the right zones.