### PR TITLE
Hotfix/cs/fill in the blank correct answer

### DIFF
--- a/client/js/_author/components/assessments/question_types/movable_fill_blank/movable_fill_blank.jsx
+++ b/client/js/_author/components/assessments/question_types/movable_fill_blank/movable_fill_blank.jsx
@@ -44,6 +44,7 @@ class MovableFillBlank extends React.Component {
                 <Option
                   key={`assessmentChoice_${choice.id}_${this.props.language}`}
                   {...choice}
+                  itemId={this.props.item.id}
                   updateChoice={newChoice => this.props.updateChoice(id, choice.id, newChoice)}
                   deleteChoice={() => this.props.deleteChoice({ id: choice.id })}
                   setActiveChoice={this.props.selectChoice}

--- a/client/js/_author/components/assessments/question_types/movable_fill_blank/movable_fill_blank.spec.jsx
+++ b/client/js/_author/components/assessments/question_types/movable_fill_blank/movable_fill_blank.spec.jsx
@@ -4,7 +4,6 @@ import MovableFillBlank   from './movable_fill_blank';
 import Feedback           from '../question_common/single_feedback';
 import Option             from './option';
 import Add                from '../question_common/add_option';
-import Radio              from '../question_common/option_radio';
 
 describe('movable_fill_blank component', () => {
   let props;

--- a/client/js/_author/components/assessments/question_types/movable_fill_blank/movable_fill_blank.spec.jsx
+++ b/client/js/_author/components/assessments/question_types/movable_fill_blank/movable_fill_blank.spec.jsx
@@ -4,6 +4,7 @@ import MovableFillBlank   from './movable_fill_blank';
 import Feedback           from '../question_common/single_feedback';
 import Option             from './option';
 import Add                from '../question_common/add_option';
+import Radio              from '../question_common/option_radio';
 
 describe('movable_fill_blank component', () => {
   let props;
@@ -64,6 +65,16 @@ describe('movable_fill_blank component', () => {
 
   it('renders option', () => {
     expect(result.find(Option)).toBeDefined();
+  });
+
+  it('renders unchecked options', () => {
+    expect(result.find(Option).first().html()).not.toContain('checked=""');
+  });
+
+  it('renders checked options', () => {
+    props.item.question.choices.choice.isCorrect = true;
+    result = shallow(<MovableFillBlank {...props} />);
+    expect(result.find(Option).first().html()).toContain('checked=""');
   });
 
   it('renders add option', () => {


### PR DESCRIPTION
Fixes a bug reported by Keerthi, where if there are multiple fill-in-the-blank questions in an assessment, only the last one shows the "correct" radio button visually checked. This passes through the `itemId` parameter, which then gives each radio button a unique name and solves that conflict.

Depends on PR #151 .