### PR TITLE
fix droppable mouse jumping

### DIFF
--- a/client/js/_player/components/common/clix_drag_and_drop/droppable.jsx
+++ b/client/js/_player/components/common/clix_drag_and_drop/droppable.jsx
@@ -5,7 +5,17 @@ import ItemTypes          from '../draggable_item_types';
 
 const droppableSource = {
   beginDrag(props, monitor, component) {
-    const bounds = component.node.getBoundingClientRect();
+    // const bounds = component.node.getBoundingClientRect();
+    // This assumes that the droppable "innerHTML", set by the
+    //   author, only has ONE root DOM element, be it an
+    //   <img> tag, or a wrapping <div>, etc.
+    // By checking the height of the child, we ensure that the
+    //   droppable is dragged by the center of the desired image / text.
+    // This fixes a bug where one droppable might be very tall compared
+    //   to the others, which made the Droppable components all
+    //   the same height in the player...and the mouse would jump
+    //   to the middle of the Droppable and off the small images.
+    const bounds = component.node.firstChild.getBoundingClientRect();
     const body = document.getElementsByTagName('body')[0];
     body.className = 'dragging';
     return {


### PR DESCRIPTION
This solves an issue reported by Prachi, where dragging an image jumped the mouse pointer off the image, making the action very unintuitive.

![captura de pantalla 2017-08-10 a la s 9 41 50 am](https://user-images.githubusercontent.com/4930129/29173099-2d91f70a-7db0-11e7-8a46-0578db3baacf.png)

In this example problem, the chair image is very tall, making the wrapping `<div>` elements around all the droppables tall -- you can see the gray outline on each of them. The original code grabbed the height of the gray outline `<div>`, and moved the pointer to the center of that height -- which mean the mouse would be offcenter from the smaller images.

![drag-and-drop-clipped](https://user-images.githubusercontent.com/4930129/29173395-25c1cc20-7db1-11e7-89d5-5321b51b4ad9.gif)

This would make dragging "short" images, like the doormat, counterintuitive, especially when the zone is also thin / near the edge of the background image. The doormat, for example, would bounce back to the droppable zones if you tried dropping it onto the right zone, because the mouse pointer would be off the background image.

This fix makes the droppable code find the height of the enclosed `<img>` or "root" element, instead of the wrapping `<div>`.