### PR TITLE
use react-helmet to adjust html lang attribute depending on locale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ branches:
 before_install:
   - cp .env.example .env
   - cp client/ci.karma.conf.js client/karma.conf.js
-  - nvm install 7.5.0
-  - nvm use 7.5.0
+  - nvm install 8.0.0
+  - nvm use 8.0.0
   - npm install -g yarn
 
 install:

--- a/client/js/_player/components/main/assessment.jsx
+++ b/client/js/_player/components/main/assessment.jsx
@@ -112,6 +112,7 @@ export class Assessment extends React.Component {
         unansweredQuestionWarning: React.PropTypes.string,
         leavingQuizPopup: React.PropTypes.string,
       }),
+      getLanguage: React.PropTypes.func
     }),
     currentItem: React.PropTypes.number,
     correctItemCount: React.PropTypes.number,
@@ -382,7 +383,6 @@ export class Assessment extends React.Component {
         );
       }
     }
-    console.log('trying to set html lang to ', this.props.localizedStrings.getLanguage())
     return (
       <div
         className="o-assessment-container"

--- a/client/js/_player/components/main/assessment.jsx
+++ b/client/js/_player/components/main/assessment.jsx
@@ -1,5 +1,6 @@
 import React        from 'react';
 import { connect }  from 'react-redux';
+import { Helmet } from 'react-helmet';
 
 import * as AssessmentProgress    from '../../actions/assessment_progress';
 import * as CommunicationActions  from '../../actions/communications';
@@ -381,13 +382,16 @@ export class Assessment extends React.Component {
         );
       }
     }
-
+    console.log('trying to set html lang to ', this.props.localizedStrings.getLanguage())
     return (
       <div
         className="o-assessment-container"
         lang={this.props.settings.locale}
         dir={this.props.localizedStrings.dir}
       >
+        <Helmet>
+          <html lang={this.props.localizedStrings.getLanguage()} />
+        </Helmet>
         <div className="c-header">
           {this.renderRemainingStatus()}
           <div className="c-header__title">{titleText}</div>

--- a/client/package.json
+++ b/client/package.json
@@ -20,6 +20,7 @@
     "react-dnd": "^2.1.4",
     "react-dnd-html5-backend": "^2.1.2",
     "react-dom": "^15.4.2",
+    "react-helmet": "^5.2.0",
     "react-localization": "0.0.2",
     "react-modal": "^1.7.1",
     "react-paginate": "^4.2.0",

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2459,7 +2459,7 @@ deep-eql@^0.1.3:
   dependencies:
     type-detect "0.1.1"
 
-deep-equal@^1.0.0:
+deep-equal@^1.0.0, deep-equal@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
 
@@ -3211,6 +3211,10 @@ exec-sh@^0.2.0:
 exenv@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.0.tgz#3835f127abf075bfe082d0aed4484057c78e3c89"
+
+exenv@^1.2.1:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/exenv/-/exenv-1.2.2.tgz#2ae78e85d9894158670b03d47bec1f03bd91bb9d"
 
 exit-hook@^1.0.0:
   version "1.1.1"
@@ -7487,6 +7491,15 @@ react-dom@^15.4.2:
     object-assign "^4.1.0"
     prop-types "~15.5.7"
 
+react-helmet@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/react-helmet/-/react-helmet-5.2.0.tgz#a81811df21313a6d55c5f058c4aeba5d6f3d97a7"
+  dependencies:
+    deep-equal "^1.0.1"
+    object-assign "^4.1.1"
+    prop-types "^15.5.4"
+    react-side-effect "^1.1.0"
+
 react-hot-loader@^3.0.0-beta.6:
   version "3.0.0-beta.6"
   resolved "https://registry.yarnpkg.com/react-hot-loader/-/react-hot-loader-3.0.0-beta.6.tgz#463fac0bfc8b63a8385258af20c91636abce75f4"
@@ -7567,6 +7580,13 @@ react-router@^3.0.2:
     loose-envify "^1.2.0"
     prop-types "^15.5.6"
     warning "^3.0.0"
+
+react-side-effect@^1.1.0:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/react-side-effect/-/react-side-effect-1.1.3.tgz#512c25abe0dec172834c4001ec5c51e04d41bc5c"
+  dependencies:
+    exenv "^1.2.1"
+    shallowequal "^1.0.1"
 
 react-tap-event-plugin@2.0.1:
   version "2.0.1"
@@ -8432,6 +8452,10 @@ sha@~2.0.1:
   dependencies:
     graceful-fs "^4.1.2"
     readable-stream "^2.0.2"
+
+shallowequal@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.0.2.tgz#1561dbdefb8c01408100319085764da3fcf83f8f"
 
 shell-quote@~1.4.1:
   version "1.4.3"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "QTI client and authoring tool written in React.js",
   "engines": {
-    "node": "7.4.0"
+    "node": "8.0.0"
   },
   "author": "atomicjolt",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "QTI client and authoring tool written in React.js",
   "engines": {
-    "node": "8.0.0"
+    "node": ">7.4.0"
   },
   "author": "atomicjolt",
   "license": "MIT",


### PR DESCRIPTION
To test this, you can run `yarn hot` (even without qbank running). Check the `html` `lang` attribute in Dev Tools. It should show `en`. Change the URL to include `?locale=hi`, then in Dev tools you should see `<html lang="hi">`.