### PR TITLE
add aria-hidden attribute to words removed from word cloud

### DIFF
--- a/client/js/_player/components/common/item_chain.jsx
+++ b/client/js/_player/components/common/item_chain.jsx
@@ -120,7 +120,6 @@ export default class ItemChain extends React.Component {
       let startBlock = (
         <div
           className={startBlockClassName}
-          aria-hidden
         />);
 
       if(this.props.noStartBlock) {

--- a/client/js/_player/components/common/item_chain.jsx
+++ b/client/js/_player/components/common/item_chain.jsx
@@ -117,7 +117,11 @@ export default class ItemChain extends React.Component {
         }
       }
 
-      let startBlock = <div className={startBlockClassName} />;
+      let startBlock = (
+        <div
+          className={startBlockClassName}
+          aria-hidden
+        />);
 
       if(this.props.noStartBlock) {
         startBlock = <div></div>;

--- a/client/js/_player/components/common/word.jsx
+++ b/client/js/_player/components/common/word.jsx
@@ -3,6 +3,11 @@ import React            from "react";
 export default class Word extends React.Component {
   render() {
     const className = this.props.hide ? this.props.className + " u-hide" : this.props.className;
-    return <div className={className} dangerouslySetInnerHTML={{__html: this.props.material}} />
+    return (
+      <div
+        className={className}
+        aria-hidden={this.props.hide}
+        dangerouslySetInnerHTML={{ __html: this.props.material }}
+      />)
   }
 }

--- a/client/js/_player/components/common/word.jsx
+++ b/client/js/_player/components/common/word.jsx
@@ -1,13 +1,19 @@
-import React            from "react";
+import React            from 'react';
 
 export default class Word extends React.Component {
   render() {
-    const className = this.props.hide ? this.props.className + " u-hide" : this.props.className;
+    const className = this.props.hide ? `${this.props.className} u-hide` : this.props.className;
     return (
       <div
         className={className}
         aria-hidden={this.props.hide}
         dangerouslySetInnerHTML={{ __html: this.props.material }}
-      />)
+      />);
   }
 }
+
+Word.propTypes = {
+  hide: React.PropTypes.bool.isRequired,
+  material: React.PropTypes.string.isRequired,
+  className: React.PropTypes.string.isRequired,
+};


### PR DESCRIPTION
Not really sure we need the `aria-hidden` attribute set on the `item_chain` component, since that shows up as the "starting" block for each row (the `[` on the first row or the `>>` on the second row) and not the actual text, but I've included it here. Let me know if it's unnecessary.