### PR TITLE
send up all answers when updating MC choice

### DIFF
--- a/client/js/_author/components/assessments/question_types/multiple_choice/option_feedback.jsx
+++ b/client/js/_author/components/assessments/question_types/multiple_choice/option_feedback.jsx
@@ -26,6 +26,7 @@ class optionFeedback extends React.Component {
         <label htmlFor="feedback1">{strings.feedback}</label>
         <Editor
           editorKey={getLanguage(this.props.language)}
+          language={this.props.language}
           textSize="smaller"
           fileIds={this.props.fileIds}
           text={languageText(this.props.feedbacks, this.props.language)}

--- a/client/js/_author/components/assessments/question_types/question_common/single_feedback.jsx
+++ b/client/js/_author/components/assessments/question_types/question_common/single_feedback.jsx
@@ -33,6 +33,7 @@ export default class SingleFeedback extends React.Component {
         <label htmlFor="feedbackCorrect">{this.props.labelText}</label>
         <Editor
           editorKey={getLanguage(this.props.language)}
+          language={this.props.language}
           textSize="smaller"
           fileIds={_.get(this.props.feedback, 'fileIds')}
           text={text}

--- a/client/js/middleware/serialization/qbank/serializers/multiple_choice.js
+++ b/client/js/middleware/serialization/qbank/serializers/multiple_choice.js
@@ -57,7 +57,7 @@ function serializeAnswers(originalChoices, newChoiceAttributes, language) {
     if (_.get(choice, 'isCorrect')) { correctId = key; }
   });
 
-  const serializedAnswers = _(newChoiceAttributes)
+  const serializedAnswers = _(originalChoices)
   .entries()
   .filter(choice =>
     choice[1].id !== 'new' &&

--- a/client/js/middleware/serialization/qbank/serializers/multiple_choice.js
+++ b/client/js/middleware/serialization/qbank/serializers/multiple_choice.js
@@ -66,16 +66,17 @@ function serializeAnswers(originalChoices, newChoiceAttributes, language) {
     const originalChoiceId = choice[0];
     const original = choice[1];
     const newChoice = newChoiceAttributes[originalChoiceId];
-    const text = (newChoice && newChoice.feedback) ||
-      findLanguageText(original.feedbacks, language);
+    const text = newChoice
+      ? newChoice.feedback
+      : findLanguageText(original.feedbacks, language);
     return scrub({
       id: original.answerId,
       genusTypeId: correctAnswer(correctId, original.id, original.isCorrect),
       feedback: languageText(text, language),
       type: genusTypes.answer.multipleChoice,
       choiceIds: [original.id],
-      fileIds: (newChoice && newChoice.fileIds) || null,
-      delete: (newChoice && newChoice.delete) || null
+      fileIds: newChoice ? newChoice.fileIds : null,
+      delete: newChoice ? newChoice.delete : null
     });
   })
   .value();

--- a/client/js/middleware/serialization/qbank/serializers/multiple_choice.js
+++ b/client/js/middleware/serialization/qbank/serializers/multiple_choice.js
@@ -56,7 +56,6 @@ function serializeAnswers(originalChoices, newChoiceAttributes, language) {
   _.forEach(newChoiceAttributes, (choice, key) => {
     if (_.get(choice, 'isCorrect')) { correctId = key; }
   });
-
   const serializedAnswers = _(originalChoices)
   .entries()
   .filter(choice =>
@@ -64,16 +63,19 @@ function serializeAnswers(originalChoices, newChoiceAttributes, language) {
     (!_.isUndefined(choice[1].feedback) || !_.isUndefined(choice[1].isCorrect))
   )
   .map((choice) => {
-    const original = originalChoices[choice[0]];
-    const text = choice[1].feedback || findLanguageText(original.feedbacks, language);
+    const originalChoiceId = choice[0];
+    const original = choice[1];
+    const newChoice = newChoiceAttributes[originalChoiceId];
+    const text = (newChoice && newChoice.feedback) ||
+      findLanguageText(original.feedbacks, language);
     return scrub({
       id: original.answerId,
       genusTypeId: correctAnswer(correctId, original.id, original.isCorrect),
       feedback: languageText(text, language),
       type: genusTypes.answer.multipleChoice,
       choiceIds: [original.id],
-      fileIds: choice[1].fileIds,
-      delete: choice[1].delete,
+      fileIds: (newChoice && newChoice.fileIds) || null,
+      delete: (newChoice && newChoice.delete) || null
     });
   })
   .value();

--- a/client/js/middleware/serialization/qbank/serializers/multiple_choice.js
+++ b/client/js/middleware/serialization/qbank/serializers/multiple_choice.js
@@ -63,20 +63,20 @@ function serializeAnswers(originalChoices, newChoiceAttributes, language) {
     (!_.isUndefined(choice[1].feedback) || !_.isUndefined(choice[1].isCorrect))
   )
   .map((choice) => {
-    const originalChoiceId = choice[0];
-    const original = choice[1];
-    const newChoice = newChoiceAttributes[originalChoiceId];
-    const text = newChoice
-      ? newChoice.feedback
-      : findLanguageText(original.feedbacks, language);
+      const originalChoiceId = choice[0];
+      const original = choice[1];
+      const newChoice = newChoiceAttributes[originalChoiceId];
+      const text = newChoice
+        ? newChoice.feedback
+        : findLanguageText(original.feedbacks, language);
     return scrub({
       id: original.answerId,
       genusTypeId: correctAnswer(correctId, original.id, original.isCorrect),
       feedback: languageText(text, language),
       type: genusTypes.answer.multipleChoice,
       choiceIds: [original.id],
-      fileIds: newChoice ? newChoice.fileIds : null,
-      delete: newChoice ? newChoice.delete : null
+        fileIds: newChoice ? newChoice.fileIds : null,
+        delete: newChoice ? newChoice.delete : null
     });
   })
   .value();

--- a/client/js/middleware/serialization/qbank/serializers/multiple_choice.js
+++ b/client/js/middleware/serialization/qbank/serializers/multiple_choice.js
@@ -63,20 +63,20 @@ function serializeAnswers(originalChoices, newChoiceAttributes, language) {
     (!_.isUndefined(choice[1].feedback) || !_.isUndefined(choice[1].isCorrect))
   )
   .map((choice) => {
-      const originalChoiceId = choice[0];
-      const original = choice[1];
-      const newChoice = newChoiceAttributes[originalChoiceId];
-      const text = newChoice
-        ? newChoice.feedback
-        : findLanguageText(original.feedbacks, language);
+    const originalChoiceId = choice[0];
+    const original = choice[1];
+    const newChoice = newChoiceAttributes[originalChoiceId];
+    const text = newChoice
+      ? newChoice.feedback
+      : findLanguageText(original.feedbacks, language);
     return scrub({
       id: original.answerId,
       genusTypeId: correctAnswer(correctId, original.id, original.isCorrect),
       feedback: languageText(text, language),
       type: genusTypes.answer.multipleChoice,
       choiceIds: [original.id],
-        fileIds: newChoice ? newChoice.fileIds : null,
-        delete: newChoice ? newChoice.delete : null
+      fileIds: newChoice ? newChoice.fileIds : null,
+      delete: newChoice ? newChoice.delete : null
     });
   })
   .value();

--- a/client/js/middleware/serialization/qbank/serializers/multiple_choice.spec.js
+++ b/client/js/middleware/serialization/qbank/serializers/multiple_choice.spec.js
@@ -129,4 +129,27 @@ describe('multipleChoice serializer', () => {
     expect(result.answers[1].genusTypeId).toBe(genusTypes.answer.rightAnswer);
     expect(result.answers[2].genusTypeId).toBe(genusTypes.answer.wrongAnswer);
   });
+
+  it('should change the correct choice answer', () => {
+    // Because for MultipleChoice, the other answers / choices
+    //   also need to be updated with `isCorrect` = `false`,
+    //   so verify that works.
+    newItem = {
+      id: 'item01',
+      question: {
+        choices: {
+          choice01: {
+            id: 'choice01',
+            isCorrect: true
+          },
+        }
+      }
+    };
+    result = multipleChoice(item, newItem);
+    expect(result.answers.length).toBe(3);
+    expect(result.answers[0].genusTypeId).toBe(genusTypes.answer.rightAnswer);
+    expect(result.answers[1].genusTypeId).toBe(genusTypes.answer.wrongAnswer);
+    expect(result.answers[2].genusTypeId).toBe(genusTypes.answer.wrongAnswer);
+
+  });
 });


### PR DESCRIPTION
Original bug: With MC questions, after you select multiple choices as correct, you cannot switch back again (i.e. create a question with two choices, pick A then B, and you cannot switch back to A). This was because the app was only sending back "correct" answers without setting the previously correct answer(s) as "incorrect", leading qbank to eventually flag every answer as correct. Issue #131 .

This has been fixed so that MC questions will also update the incorrect answers when a correct one is selected. You can test this manually in the authoring tool by creating a MC question with two choices, and toggling between them to alternate which one is correct. Publish / test to verify that only the selected one is correct.

This stems from this commit: https://github.com/CLIxIndia-Dev/OpenAssessmentsClient/commit/1808b0ed8a903d2554cf4dfcc64c66cc4350ea7e#diff-a985eea302efbc6336bf487189120a26R60

Where only the newly updated Choices are iterated through. Note the previous code iterates through `originalChoices` instead: https://github.com/CLIxIndia-Dev/OpenAssessmentsClient/commit/1808b0ed8a903d2554cf4dfcc64c66cc4350ea7e#diff-a985eea302efbc6336bf487189120a26L59

For MultipleChoice, because you have to update all the answers when you select the "correct" answer, you have to iterate over the `originalChoices`, not just `newChoiceAttributes`, which only includes the newly changed / updated choice.

I also added a test to make sure this doesn't revert in the future.