### PR TITLE
remove green checkmark on multi-answer survey questions

### DIFF
--- a/client/js/_player/components/assessments/item.jsx
+++ b/client/js/_player/components/assessments/item.jsx
@@ -138,6 +138,7 @@ export default class Item extends React.Component {
       if (questionResult.correct === true) {
         switch (questionType) {
           case 'survey_question':
+          case 'multiple_answer_survey_question':
             answerFeedback = (
               <div className="c-question-feedback  c-feedback--correct">
                 <div dangerouslySetInnerHTML={{ __html: questionResult.feedback }} />

--- a/client/js/_player/components/assessments/item.spec.jsx
+++ b/client/js/_player/components/assessments/item.spec.jsx
@@ -168,6 +168,23 @@ describe('item', () => {
       expect(subject.textContent).not.toContain('Incorrect answer');
     });
 
+    it('renders multi-select survey question without tick mark when item is correct', () => {
+      question = {
+        question_type: 'multiple_answer_survey_question', // set question type
+        answers: []
+      };
+      questionResult = { correct:true, feedback:'Correct answer' };
+      numQuestionsChecking = 0;
+      renderItem();
+      svgTest = TestUtils.scryRenderedDOMComponentsWithTag(result, 'svg'); // look for svg tag
+      expect(svgTest.length).toEqual(0); // expect no svg tag
+      expect(question.question_type).toContain('survey_question');
+      expect(subject.textContent).toContain('Correct');
+      expect(subject.textContent).toContain('Correct answer');
+      expect(subject.textContent).not.toContain('Incorrect');
+      expect(subject.textContent).not.toContain('Incorrect answer');
+    });
+
     it('renders incorrect when item is incorrect', () => {
       questionResult = { correct:false, feedback:'Incorrect answer' };
       numQuestionsChecking = 0;

--- a/client/js/_player/components/assessments/universal_input.jsx
+++ b/client/js/_player/components/assessments/universal_input.jsx
@@ -211,7 +211,8 @@ export default class UniversalInput extends React.Component {
         );
         break;
       }
-      case 'multiple_answers_question': {
+      case 'multiple_answers_question':
+      case 'multiple_answer_survey_question': {
         const multipleAnswer = (answer) => {
           const selectCheckbox = _.partialRight(props.selectAnswer, false);
           const id = `${item.id}_${answer.id}`;

--- a/client/js/_player/components/assessments/universal_input.spec.jsx
+++ b/client/js/_player/components/assessments/universal_input.spec.jsx
@@ -386,6 +386,54 @@ describe('Assessment Questions', () => {
     });
   });
 
+  describe('Multiple Answer Survey Question', () => {
+    beforeEach(() => {
+      item = {
+        id       : 0,
+        question_type: 'multiple_answer_survey_question',
+        url      : 'www.iamcool.com',
+        title    : 'title',
+        xml      : null,
+        standard : 'edX',
+        edXMaterial : '<p>hello world</p>',
+        answers  : [{ id: '0', material: 'test1' }, { id: '1', material: 'test2' }],
+        isGraded : true,
+        material: '<p>hello world</p>',
+        messages : ['My Message1', 'My Message2'],
+        solution : '<p>solution text</p>'
+      };
+
+      Content = (
+        <UniversalInput
+          settings={{}}
+          item={item}
+          selectAnswer={selectAnswer}
+        />
+      );
+      result = TestUtils.renderIntoDocument(Content);
+    });
+
+    afterEach(() => {
+      item = {};
+      Content = '';
+      result = '';
+    });
+
+    it('Renders the checkboxes', () => {
+      expect(TestUtils.scryRenderedComponentsWithType(result, 'checkbox')).toBeDefined();
+    });
+
+    it('Renders the a11y components', () => {
+      expect(TestUtils.scryRenderedComponentsWithType(result, 'fieldset')).toBeDefined();
+      expect(TestUtils.scryRenderedComponentsWithType(result, 'legend')).toBeDefined();
+    });
+
+    it('Checkbox text is rendered', () => {
+      expect(ReactDOM.findDOMNode(result).textContent).toContain(item.answers[0].material);
+      expect(ReactDOM.findDOMNode(result).textContent).toContain(item.answers[1].material);
+    });
+  });
+
   describe('Edx Image Mapped Input', () => {
     beforeEach(() => {
       item = {

--- a/client/js/_player/components/assessments/universal_input.spec.jsx
+++ b/client/js/_player/components/assessments/universal_input.spec.jsx
@@ -3,6 +3,7 @@ import ReactDOM                  from 'react-dom';
 import TestUtils                 from 'react-dom/test-utils';
 import { mount, shallow }        from 'enzyme';
 import UniversalInput            from './universal_input';
+import CheckBox                  from '../common/checkbox';
 
 describe('Assessment Questions', () => {
 
@@ -362,7 +363,7 @@ describe('Assessment Questions', () => {
           selectAnswer={selectAnswer}
         />
       );
-      result = TestUtils.renderIntoDocument(Content);
+      result = mount(Content);
     });
 
     afterEach(() => {
@@ -372,7 +373,7 @@ describe('Assessment Questions', () => {
     });
 
     it('Renders the checkboxes', () => {
-      expect(TestUtils.scryRenderedComponentsWithType(result, 'checkbox')).toBeDefined();
+      expect(result.find(CheckBox).length).toEqual(2);
     });
 
     it('Renders the a11y components', () => {
@@ -381,8 +382,8 @@ describe('Assessment Questions', () => {
     });
 
     it('Checkbox text is rendered', () => {
-      expect(ReactDOM.findDOMNode(result).textContent).toContain(item.answers[0].material);
-      expect(ReactDOM.findDOMNode(result).textContent).toContain(item.answers[1].material);
+      expect(result.find(CheckBox).first().html()).toContain(item.answers[0].material);
+      expect(result.find(CheckBox).last().html()).toContain(item.answers[1].material);
     });
   });
 
@@ -410,7 +411,7 @@ describe('Assessment Questions', () => {
           selectAnswer={selectAnswer}
         />
       );
-      result = TestUtils.renderIntoDocument(Content);
+      result = mount(Content);
     });
 
     afterEach(() => {
@@ -420,7 +421,7 @@ describe('Assessment Questions', () => {
     });
 
     it('Renders the checkboxes', () => {
-      expect(TestUtils.scryRenderedComponentsWithType(result, 'checkbox')).toBeDefined();
+      expect(result.find(CheckBox).length).toEqual(2);
     });
 
     it('Renders the a11y components', () => {
@@ -429,8 +430,8 @@ describe('Assessment Questions', () => {
     });
 
     it('Checkbox text is rendered', () => {
-      expect(ReactDOM.findDOMNode(result).textContent).toContain(item.answers[0].material);
-      expect(ReactDOM.findDOMNode(result).textContent).toContain(item.answers[1].material);
+      expect(result.find(CheckBox).first().html()).toContain(item.answers[0].material);
+      expect(result.find(CheckBox).last().html()).toContain(item.answers[1].material);
     });
   });
 

--- a/client/js/parsers/clix/clix.js
+++ b/client/js/parsers/clix/clix.js
@@ -56,7 +56,8 @@ export function transformItem(item) {
         'question-type%3Aqti-order-interaction-object-manipulation%40ODL.MIT.EDU': 'movable_object_chain',
         'question-type%3Aqti-upload-interaction-generic%40ODL.MIT.EDU': 'file_upload_question',
         'question-type%3Aqti-numeric-response%40ODL.MIT.EDU': 'numerical_input_question',
-        'question-type%3Aqti-choice-interaction-survey%40ODL.MIT.EDU': 'survey_question'
+        'question-type%3Aqti-choice-interaction-survey%40ODL.MIT.EDU': 'survey_question',
+        'question-type%3Aqti-choice-interaction-multi-select-survey%40ODL.MIT.EDU': 'multiple_answer_survey_question'
       };
 
       if (mapGenusType[item.json.genusTypeId]) {

--- a/client/js/parsers/clix/clix.spec.js
+++ b/client/js/parsers/clix/clix.spec.js
@@ -38,24 +38,23 @@ describe('transformItem', () => {
         },
         title: '',
         xml: '',
-      },
-      {
-        json: {
-          genusTypeId: 'question-type%3Aqti-choice-interaction-multi-select-survey%40ODL.MIT.EDU',
-        },
-        title: '',
-        xml: '',
-      },
-      {
-        json: {
-          genusTypeId: 'question-type%3Aqti-choice-interaction-survey%40ODL.MIT.EDU',
-        },
-        title: '',
-        xml: '',
       }],
     },
   };
-
+  const multiSelectSurvey = {
+    json: {
+      genusTypeId: 'question-type%3Aqti-choice-interaction-multi-select-survey%40ODL.MIT.EDU',
+    },
+    title: '',
+    xml: '',
+  };
+  const survey = {
+    json: {
+      genusTypeId: 'question-type%3Aqti-choice-interaction-survey%40ODL.MIT.EDU',
+    },
+    title: '',
+    xml: '',
+  };
 
   it('transforms ART question with timeValue into allQuestions state', () => {
     // the clix parser expects xml, pass it in as a file
@@ -84,7 +83,7 @@ describe('transformItem', () => {
 
   it('transforms multi-select Reflection question type', () => {
     data = readFixture('clix/multi-select-survey-question.xml');
-    item = state.assessment.items[3];
+    item = multiSelectSurvey;
     item.xml = $($.parseXML(data));
     result = transformItem(item);
     expect(result.question_type).toEqual('multiple_answer_survey_question');
@@ -92,7 +91,7 @@ describe('transformItem', () => {
 
   it('transforms Reflection question type', () => {
     data = readFixture('clix/survey-question.xml');
-    item = state.assessment.items[4];
+    item = survey;
     item.xml = $($.parseXML(data));
     result = transformItem(item);
     expect(result.question_type).toEqual('survey_question');

--- a/client/js/parsers/clix/clix.spec.js
+++ b/client/js/parsers/clix/clix.spec.js
@@ -38,6 +38,20 @@ describe('transformItem', () => {
         },
         title: '',
         xml: '',
+      },
+      {
+        json: {
+          genusTypeId: 'question-type%3Aqti-choice-interaction-multi-select-survey%40ODL.MIT.EDU',
+        },
+        title: '',
+        xml: '',
+      },
+      {
+        json: {
+          genusTypeId: 'question-type%3Aqti-choice-interaction-survey%40ODL.MIT.EDU',
+        },
+        title: '',
+        xml: '',
       }],
     },
   };
@@ -66,5 +80,21 @@ describe('transformItem', () => {
     item.xml = $($.parseXML(data));
     result = transformItem(item);
     expect(result.audioTimeout).toEqual(null);
+  });
+
+  it('transforms multi-select Reflection question type', () => {
+    data = readFixture('clix/multi-select-survey-question.xml');
+    item = state.assessment.items[3];
+    item.xml = $($.parseXML(data));
+    result = transformItem(item);
+    expect(result.question_type).toEqual('multiple_answer_survey_question');
+  });
+
+  it('transforms Reflection question type', () => {
+    data = readFixture('clix/survey-question.xml');
+    item = state.assessment.items[4];
+    item.xml = $($.parseXML(data));
+    result = transformItem(item);
+    expect(result.question_type).toEqual('survey_question');
   });
 });

--- a/client/specs_support/fixtures/clix/multi-select-survey-question.xml
+++ b/client/specs_support/fixtures/clix/multi-select-survey-question.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assessmentItem adaptive="False" identifier="assessment.Item%3A59382ed2c89cd95ade2ba0d1%40assessment-session" timeDependent="False" title="" xml_ns="http://www.imsglobal.org/xsd/imsqti_v2p1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1p1.xsd http://www.w3.org/1998/Math/MathML http://www.w3.org/Math/XMLSchema/mathml2/mathml2.xsd">
+  <outcomeDeclaration baseType="float" cardinality="single" identifier="SCORE">
+    <defaultValue>
+      <value>0</value>
+    </defaultValue>
+  </outcomeDeclaration>
+  <outcomeDeclaration baseType="float" cardinality="single" identifier="MAXSCORE">
+    <defaultValue>
+      <value>1</value>
+    </defaultValue>
+  </outcomeDeclaration>
+  <outcomeDeclaration baseType="float" cardinality="single" identifier="MINSCORE" view="testConstructor">
+    <defaultValue>
+      <value>0</value>
+    </defaultValue>
+  </outcomeDeclaration>
+  <outcomeDeclaration baseType="identifier" cardinality="single" identifier="FEEDBACKBASIC">
+    <defaultValue>
+      <value>empty</value>
+    </defaultValue>
+  </outcomeDeclaration>
+  <itemBody>
+    <p>pick some choices</p>
+    <choiceInteraction responseIdentifier="RESPONSE_1" shuffle="true" maxChoices="0">
+      <simpleChoice identifier="366db442-9db3-3b74-f072-59e18a3cf8bd">
+        <p class="other">the</p>
+      </simpleChoice>
+      <simpleChoice identifier="3f9485a8-0e45-d04f-8ec4-228fbddaef1b">
+        <p class="adverb">here</p>
+      </simpleChoice>
+      <simpleChoice identifier="22fc7cd6-9654-8da6-f47d-06487b224821">
+        <p class="verb">hops</p>
+      </simpleChoice>
+      <simpleChoice identifier="6520fc34-8b7b-d4b2-c139-44c6e081303f">
+        <p class="noun">bunny</p>
+      </simpleChoice>
+    </choiceInteraction>
+  </itemBody>
+</assessmentItem>

--- a/client/specs_support/fixtures/clix/survey-question.xml
+++ b/client/specs_support/fixtures/clix/survey-question.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assessmentItem adaptive="False" identifier="assessment.Item%3A59382ed2c89cd95ade2ba0d1%40assessment-session" timeDependent="False" title="" xml_ns="http://www.imsglobal.org/xsd/imsqti_v2p1" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.imsglobal.org/xsd/imsqti_v2p1 http://www.imsglobal.org/xsd/qti/qtiv2p1/imsqti_v2p1p1.xsd http://www.w3.org/1998/Math/MathML http://www.w3.org/Math/XMLSchema/mathml2/mathml2.xsd">
+  <outcomeDeclaration baseType="float" cardinality="single" identifier="SCORE">
+    <defaultValue>
+      <value>0</value>
+    </defaultValue>
+  </outcomeDeclaration>
+  <outcomeDeclaration baseType="float" cardinality="single" identifier="MAXSCORE">
+    <defaultValue>
+      <value>1</value>
+    </defaultValue>
+  </outcomeDeclaration>
+  <outcomeDeclaration baseType="float" cardinality="single" identifier="MINSCORE" view="testConstructor">
+    <defaultValue>
+      <value>0</value>
+    </defaultValue>
+  </outcomeDeclaration>
+  <outcomeDeclaration baseType="identifier" cardinality="single" identifier="FEEDBACKBASIC">
+    <defaultValue>
+      <value>empty</value>
+    </defaultValue>
+  </outcomeDeclaration>
+  <itemBody>
+    <p>pick some choices</p>
+    <choiceInteraction responseIdentifier="RESPONSE_1" shuffle="true" maxChoices="1">
+      <simpleChoice identifier="366db442-9db3-3b74-f072-59e18a3cf8bd">
+        <p class="other">the</p>
+      </simpleChoice>
+      <simpleChoice identifier="3f9485a8-0e45-d04f-8ec4-228fbddaef1b">
+        <p class="adverb">here</p>
+      </simpleChoice>
+      <simpleChoice identifier="22fc7cd6-9654-8da6-f47d-06487b224821">
+        <p class="verb">hops</p>
+      </simpleChoice>
+      <simpleChoice identifier="6520fc34-8b7b-d4b2-c139-44c6e081303f">
+        <p class="noun">bunny</p>
+      </simpleChoice>
+    </choiceInteraction>
+  </itemBody>
+</assessmentItem>


### PR DESCRIPTION
Looks like PR #30 only removed the checkmark for single-response survey questions. This PR should remove the checkmark for multi-response survey questions.