### PR TITLE
fix the english translation file for text area placeholder

### DIFF
--- a/client/js/_player/locales/en.js
+++ b/client/js/_player/locales/en.js
@@ -51,8 +51,8 @@ export default {
       chooseFile: 'Choose a File to Upload',
       noFile: 'No file chosen'
     },
-    shortAnswer: {
-      textArea: 'Enter answer here...'
+    textArea: {
+      placeholder: 'Enter answer here...'
     },
     middleware: {
       // Text displayed when a user tries to check an answer without


### PR DESCRIPTION
This is the format the code expects; can compare to the `hi` and `te` files.