### PR TITLE
mw sandbox no response feedback should ask for audio file

### DIFF
--- a/client/js/_player/middleware/qbank.js
+++ b/client/js/_player/middleware/qbank.js
@@ -47,6 +47,7 @@ function getFeedback(question, state) {
       return localizedStrings.middleware.mustUploadFile;
 
     case 'audio_upload_question':
+    case 'movable_words_sandbox':
       return localizedStrings.middleware.mustRecordFile;
 
     default:


### PR DESCRIPTION
If you click a MW Sandbox question without recording an audio file, currently it gives you feedback as "Please select an answer", which doesn't make sense for the question type.