### PR TITLE
only shift focus to player on item change, not on assessment load

### DIFF
--- a/client/js/_player/components/main/assessment.jsx
+++ b/client/js/_player/components/main/assessment.jsx
@@ -157,10 +157,11 @@ export class Assessment extends React.Component {
 
   componentWillReceiveProps(nextProps) {
     if (this.props.currentItem !==
-      nextProps.currentItem ||
-      this.props.assessmentLoaded !==
-      nextProps.assessmentLoaded
-    ) {
+      nextProps.currentItem) {
+      // Only shift focus here when items change, not when
+      //   the assessment loads. If you change focus when
+      //   the assessment loads, you risk skipping content
+      //   on the page.
       this.wrapper.focus();
     }
   }


### PR DESCRIPTION
On pages with content above the assessment or multiple assessments, the focus management was causing the browser to skip to the last loaded OEA player ... but on page load we really want focus to stay at the top of the page.