### PR TITLE
add in default firefox and chrome CSS for p and ul tags

### DIFF
--- a/client/styles/_player/components/_components.question-prompt.scss
+++ b/client/styles/_player/components/_components.question-prompt.scss
@@ -17,6 +17,25 @@
     width: 100%;
   }
 
+  p{
+    -webkit-margin-before: 1em;
+    -webkit-margin-after: 1em;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+  }
+
+  ul{
+    -webkit-margin-before: 1em;
+    -webkit-margin-after: 1em;
+    -webkit-margin-start: 0;
+    -webkit-margin-end: 0;
+    -webkit-padding-start: 40px;
+    list-style-type: disc;
+    margin-block-start: 1em;
+    margin-block-end: 1em;
+    padding-inline-start: 40px;
+  }
+
   .c-playback{
     display: inline-block;
     width: 2.4rem;


### PR DESCRIPTION
Put these CSS styles back in for the player, because otherwise what you see is **not** what you get from a question authoring perspective.

<img width="980" alt="captura de pantalla 2018-06-21 a la s 1 15 56 pm" src="https://user-images.githubusercontent.com/4930129/41734537-48241e34-7555-11e8-83a4-c7b24c6feceb.png">

versus

<img width="980" alt="captura de pantalla 2018-06-21 a la s 1 16 02 pm" src="https://user-images.githubusercontent.com/4930129/41734546-4d2f06fa-7555-11e8-8344-e3fc9b1e909f.png">
